### PR TITLE
Feature:PlanetsSection/index.tsx se eliminó .slice a <Table/>

### DIFF
--- a/arturito/src/components/PlanetsSection/index.tsx
+++ b/arturito/src/components/PlanetsSection/index.tsx
@@ -43,7 +43,7 @@ const Planets = () => {
 
   return (
     <div>
-      <Table columns={columns} data={data.results.slice(0, 3)} /* :D */ />
+      <Table columns={columns} data={data.results} /* :D */ />
     </div>
   );
 };


### PR DESCRIPTION
Le quité .slice al componente Table del archivo PlanetsSection/index.jsx, de esta manera se renderiza la info de pagina completa al hacer req a swapi.